### PR TITLE
Fix Redis client variable in Node.JS server

### DIFF
--- a/Portfolio-Management-System/Node.JS/index.js
+++ b/Portfolio-Management-System/Node.JS/index.js
@@ -83,7 +83,7 @@ server.listen(port, function () {
 // - setup shutdown hooks
 var shutdown_hook = function () {
     console.log('Quitting redis client');
-    redisclient.quit();
+    client.quit();
     console.log('Shutting down app');
     process.exit();
 };


### PR DESCRIPTION
## Summary
- fix shutdown hook to call `client.quit()`

## Testing
- `node --check Portfolio-Management-System/Node.JS/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68459230cc288326af71b2b27e20aabb